### PR TITLE
Improvements...

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,35 +4,30 @@
 
 ## Installation
 
-First install bunyan...
+Install bunyan and bunyan-stackdriver...
 
 ```bash
-npm install bunyan
-```
-
-Then install bunyan-stackdriver
-
-```bash
-npm install bunyan-stackdriver
+npm install bunyan bunyan-stackdriver
 ```
 
 ## Setup
 
-1. Enable [Google Cloud Logging API](https://console.cloud.google.com/apis/api/logging.googleapis.com/overview) in your Google Developer Console.
+1. Enable [Google Cloud Logging API](https://console.cloud.google.com/apis/api/logging.googleapis.com/overview)
+in your Google Developer Console.
 1. Start using `bunyan-stackdriver` to create log your messages
 
 ## Basic usage
 
 ```javascript
 var bunyan  = require("bunyan"),
-    BunyanStackDriver = require('bunyan-stackdriver'),
+    BunyanStackDriver = require("bunyan-stackdriver"),
     log;
 
 log = bunyan.createLogger({
     name: "myApp",
     streams: [{
       type: "raw", // faster; makes Bunyan send objects instead of stringifying messages
-      new BunyanStackDriver({
+      stream: new BunyanStackDriver({
         projectId: "your_project_id"
       })
     }],
@@ -57,21 +52,31 @@ new BunyanStackDriver({
 }, function errorCallback(err) { console.log(err); });
 ```
 
-* If you are running on Google Cloud Platform, authentication will be taken care of automatically. If you're running elsewhere, or wish to provide alternative authentication, you can specify the `keyFilename` pointing to a service account JSON key.
+* If you are running on Google Cloud Platform, authentication will be taken
+care of automatically. If you're running elsewhere, or wish to provide
+alternative authentication, you can specify the `keyFilename` pointing to a
+service account JSON key.
 
-* logName. Must be less than 512 characters and include only alphanumeric characters, forward-slash, underscore, hyphen and period.
+* logName. Must be less than 512 characters and include only alphanumeric
+characters, forward-slash, underscore, hyphen and period.
 
-* projectId. The id of the project. This can be omitted if the environment variable "GCLOUD_PROJECT" is set.
+* projectId. The id of the project. This can be omitted if the environment
+variable "GCLOUD_PROJECT" is set.
 
-* writeInterval. Specifies the maximum write frequency. Messages will be batched between writes to avoid exceeding API rate limits. (The default GCP limit is 20 RPS. The default setting for BunyanStackDriver is 500 ms.)
+* writeInterval. Specifies the maximum write frequency. Messages will be
+batched between writes to avoid exceeding API rate limits. (The default GCP
+limit is 20 RPS. The default setting for BunyanStackDriver is 500 ms.)
 
 * resource. See https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/MonitoredResource.
 
-* errorCallback. Will report errors during the logging process itself:
+* errorCallback. Will report errors during the logging process itself.
 
 ## Known issues
 
-* Circular objects will cause a stack overflow. For now, you can not use the `type: "raw"` setting; Bunyan's stringifier will remove circular references then.
+* Circular objects will cause a stack overflow. If you need to log object with
+circular references, either (a) preprocess them to remove the circles, or (b)
+do not use the `type: "raw"` setting and instead let Bunyan's stringifier
+remove circular references.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -61,13 +61,17 @@ new BunyanStackDriver({
 
 * logName. Must be less than 512 characters and include only alphanumeric characters, forward-slash, underscore, hyphen and period.
 
-* projectId. The id of the project.
+* projectId. The id of the project. This can be omitted if the environment variable "GCLOUD_PROJECT" is set.
 
 * writeInterval. Specifies the maximum write frequency. Messages will be batched between writes to avoid exceeding API rate limits. (The default GCP limit is 20 RPS. The default setting for BunyanStackDriver is 500 ms.)
 
 * resource. See https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/MonitoredResource.
 
 * errorCallback. Will report errors during the logging process itself:
+
+## Known issues
+
+* Circular objects will cause a stack overflow. For now, you can not use the `type: "raw"` setting; Bunyan's stringifier will remove circular references then.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ npm install bunyan-stackdriver
 ## Setup
 
 1. Enable [Google Cloud Logging API](https://console.cloud.google.com/apis/api/logging.googleapis.com/overview) in your Google Developer Console.
-2. [Create a new Client ID](https://console.cloud.google.com/apis/credentials) for a Service Account (JSON Key) and download it.
-3. Start using `bunyan-stackdriver` to create log your messages
+1. Start using `bunyan-stackdriver` to create log your messages
 
 ## Basic usage
 
@@ -31,54 +30,48 @@ var bunyan  = require("bunyan"),
 
 log = bunyan.createLogger({
     name: "myApp",
-    stream: new BunyanStackDriver({
-      authJSON: require("./your-JSON-key.json"),
-      project: "your_project_id",
-      log_id: "default"
-    }),
+    streams: [{
+      type: "raw", // faster; makes Bunyan send objects instead of stringifying messages
+      new BunyanStackDriver({
+        projectId: "your_project_id"
+      })
+    }],
     level: "error"
 });
 
 log.error("hello bunyan user");
 ```
 
-You can also pass an optional error handler.
+## Full options
 
 ```javascript
 new BunyanStackDriver({
-  authJSON: require("./your-JSON-key.json"),
-  project: "your_project_id",
-  log_id: "default"
-}, function(error){
-  console.log(error);
-});
+  keyFilename: "/path/to/keyfile.json",
+  logName: "logname",
+  projectId: "project-id",
+  writeInterval: 500, // ms
+  resource: {
+    type: "resource_type",
+    labels: {key1: value1}
+  }
+}, function errorCallback(err) { console.log(err); });
 ```
 
-##Custom Formatters
+* If you are running on Google Cloud Platform, authentication will be taken care of automatically. If you're running elsewhere, or wish to provide alternative authentication, you can specify the `keyFilename` pointing to a service account JSON key.
 
-By default the logs are formatted like so: `[LOG_LEVEL] message`, unless you specify a `customFormatter` function.
+* logName. Must be less than 512 characters and include only alphanumeric characters, forward-slash, underscore, hyphen and period.
 
-```javascript
-log = bunyan.createLogger({
-  name: "myApp",
-  stream: new BunyanStackDriver({
-    authJSON: require("./your-JSON-key.json"),
-    project: "your_project_id",
-    log_id: "default"
-    customFormatter: function(record, levelName){
-      return {text: "[" + levelName + "] " + record.msg }
-    }
-  }),
-  level: "error"
-});
-```
+* projectId. The id of the project.
+
+* writeInterval. Specifies the maximum write frequency. Messages will be batched between writes to avoid exceeding API rate limits. (The default GCP limit is 20 RPS. The default setting for BunyanStackDriver is 500 ms.)
+
+* resource. See https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/MonitoredResource.
+
+* errorCallback. Will report errors during the logging process itself:
 
 ## Links
 
 [Stackdriver Logging - Method entries.write](https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/entries/write)
-
-[Google Cloud Logging API beta nodejs client source code](https://github.com/google/google-api-nodejs-client/blob/master/apis/logging/v2beta1.js)
-
 
 ## License
 

--- a/example.js
+++ b/example.js
@@ -4,11 +4,12 @@ var bunyan  = require("bunyan"),
 
 log = bunyan.createLogger({
     name: "myApp",
-    stream: new BunyanStackDriver({
-      authJSON: require("./your-JSON-key.json"),
-      project: "your_project_id",
-      log_id: "default"
-    }),
+    streams: [{
+      type: "raw",
+      new BunyanStackDriver({
+        projectId: "your_project_id"
+      })
+    }],
     level: "error"
 });
 

--- a/example.js
+++ b/example.js
@@ -6,7 +6,7 @@ log = bunyan.createLogger({
     name: "myApp",
     streams: [{
       type: "raw",
-      new BunyanStackDriver({
+      stream: new BunyanStackDriver({
         projectId: "your_project_id"
       })
     }],

--- a/lib/bunyan-stackdriver.js
+++ b/lib/bunyan-stackdriver.js
@@ -1,14 +1,6 @@
-var util = require('util'),
-google = require('googleapis');
-
-var glogging = google.logging("v2beta1");
-
-const loggingScopes = [
-  //'https://www.googleapis.com/auth/logging.read',
-  'https://www.googleapis.com/auth/logging.write',
-  //'https://www.googleapis.com/auth/logging.admin',
-  //'https://www.googleapis.com/auth/cloud-platform'
-];
+var util = require('util');
+var google = require('gcloud');
+var Writable = require('stream').Writable;
 
 const nameFromLevel = {
   10: 'trace',
@@ -24,98 +16,101 @@ const mapLevelToSeverity = {
   info: 'INFO',
   warn: 'WARNING',
   error: 'ERROR',
-  fatal: 'EMERGENCY'
-}
+  fatal: 'ALERT'
+};
 
-function getNow() {
-    var d = new Date();
-    return JSON.parse(JSON.stringify(d).replace('Z', '000Z'));
-}
-
+util.inherits(BunyanStackDriver, Writable);
 function BunyanStackDriver(options, error) {
+  Writable.call(this, {objectMode: true});
+
   options = options || {};
-  if (!options.project) {
-    throw new Error('Project cannot be null');
-  } else {
+  if (!options.projectId) {
+    throw new Error('"projectId" cannot be null');
+  }
 
-    this.customFormatter = options.customFormatter;
-    this.project_id      = options.project;
-    this.log_id          = options.log_id || 'default';
-    this.error           = error               || function() {};
+  this.logName         = options.logName || 'default';
+  this.error           = error || function() {};
+  this.writeInterval   = options.writeInterval || 500; // ms. GCP's default limit is 20 RPS.
 
-    // https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/LogEntry#LogSeverity
-    if (options.severity) {
-      this.severity = options.severity || 'DEFAULT';
+  // object(MonitoredResource)
+  // https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/MonitoredResource
+  if (options.resource) {
+    if (options.resource.type) {
+      options.resource.labels = options.resource.labels || {}; // required
+      this.resource = options.resource;
+    } else {
+      throw new Error('Property "type" required when specifying a resource');
     }
+  } else {
+    this.resource = {
+      type: 'global',
+      labels: {}
+    };
+  }
+  
+  var gopts = {
+    projectId: options.projectId
+  };
 
-    // object(MonitoredResource)
-    // https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/MonitoredResource
-    this.resource = options.resource || {type: 'global'};
-
+  // If not provided, gcloud will attempt automatic auth.
+  if ("keyFilename" in options) {
+    gopts.keyFilename = options.authJSON;
   }
 
-  this.getLoggingClient = function (callback) {
-    google.auth.fromJSON(options.authJSON, function (err, authClient){
-      if (err) {
-          return callback(err);
-      }
-      if (authClient.createScopedRequired && authClient.createScopedRequired()) {
-          authClient = authClient.createScoped(loggingScopes);
-      }
-      callback(null, authClient);
-    });
-  }
+  this.loggingClient = google(gopts).logging();
+  this.log = this.loggingClient.log(this.logName);
+  this.entryQueue = [];
 }
 
-BunyanStackDriver.prototype.write = function write(record, callback) {
-  var self = this,
-  levelName,
-  message;
+var once = true;
 
+BunyanStackDriver.prototype._write = function write(record, encoding, callback) {
+  var timestamp;
   if (typeof record === 'string') {
-    record = JSON.parse(record);
-  }
-
-  levelName = nameFromLevel[record.level];
-
-  try {
-
-    if(self.customFormatter){
-      message = self.customFormatter(record, levelName);
-    }else if(typeof(record) == "string"){
-      message = { text: util.format('[%s] %s', levelName.toUpperCase(), record.msg)}
-    }else{
-      message = record;
+    if (once) {
+      once = false;
+      console.warn("BunyanStackDriver: use 'streams: [ type: \"raw\", stream: new BunyanStackDriver(...) ]' for better performance.");
     }
-  } catch(err) {
-    return self.error(err);
+    record = JSON.parse(record);
+    timestamp = new Date(record.time);
+  } else {
+    timestamp = record.time;
   }
 
-  self.getLoggingClient(function (err, authClient) {
-    var params = {
-      auth: authClient,
-      resource: {
-        //logName: "projects/" + self.project_id + "/logs/" + self.log_id,
-        //resource: self.resource,
-        //labels: {},
-        entries: [{
-          logName: "projects/" + self.project_id + "/logs/" + self.log_id,
-          resource: self.resource,
-          //timestamp: getNow(),
-          severity: mapLevelToSeverity[levelName] || 'DEFAULT',
-          //insertId,
-          //httpRequest,
-          //labels,
-          //operation,
-          [(message instanceof Object)?'jsonPayload':'textPayload']: message
-        }],
-        partialSuccess: true
-      }
-    };
+  // Date object in payload causes failure
+  delete record.time;
 
-    glogging.entries.write(params, function(err,data){
-      if(err) return self.error(err);
-    });
+  var entry = this.log.entry(this.resource, record);
+  // There are no public APIs for this yet:
+  // https://github.com/GoogleCloudPlatform/gcloud-node/issues/1348
+  entry.timestamp = timestamp;
+  entry.severity = mapLevelToSeverity[nameFromLevel[record.level]] || 'DEFAULT';
+
+  this.entryQueue.push(entry);
+
+  if (!this.writeQueued) {
+    this.writeQueued = true;
+    setTimeout(this._writeToServer.bind(this), this.writeInterval);
+  }
+
+  callback();
+};
+
+BunyanStackDriver.prototype._writeToServer = function () {
+  var self = this;
+
+  this.writeQueued = false;
+
+  // Atomically get the entries to send and clear the queue
+  var entries = this.entryQueue.splice(0);
+
+  // https://github.com/GoogleCloudPlatform/gcloud-node/issues/1349
+  var options = {
+  //  partialSuccess: true
+  };
+
+  this.log.write(entries, options, function (err, response) {
+    if (err) return self.error(err);
   });
 };
 

--- a/lib/bunyan-stackdriver.js
+++ b/lib/bunyan-stackdriver.js
@@ -24,13 +24,23 @@ function BunyanStackDriver(options, error) {
   Writable.call(this, {objectMode: true});
 
   options = options || {};
-  if (!options.projectId) {
-    throw new Error('"projectId" cannot be null');
+
+  var gopts = {};
+
+  if (options.projectId) {
+    gopts.projectId = options.projectId;
+  } else if (process.env.GCLOUD_PROJECT) {
+    // Noop, gcloud will pick this up.
+  } else {
+    throw new Error('option "projectId" or env variable GCLOUD_PROJECT required');
   }
 
-  this.logName         = options.logName || 'default';
-  this.error           = error || function() {};
-  this.writeInterval   = options.writeInterval || 500; // ms. GCP's default limit is 20 RPS.
+  var logName = options.logName || 'default';
+
+  this.error = error || function() {};
+
+  // ms. GCP's default limit is 20 RPS.
+  this.writeInterval = "writeInterval" in options ? options.writeInterval : 500;
 
   // object(MonitoredResource)
   // https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/MonitoredResource
@@ -48,17 +58,15 @@ function BunyanStackDriver(options, error) {
     };
   }
   
-  var gopts = {
-    projectId: options.projectId
-  };
-
   // If not provided, gcloud will attempt automatic auth.
-  if ("keyFilename" in options) {
+  if (options.keyFilename) {
     gopts.keyFilename = options.authJSON;
   }
 
-  this.loggingClient = google(gopts).logging();
-  this.log = this.loggingClient.log(this.logName);
+  var loggingClient = google(gopts).logging();
+
+  this.log = loggingClient.log(logName);
+
   this.entryQueue = [];
 }
 
@@ -77,10 +85,10 @@ BunyanStackDriver.prototype._write = function write(record, encoding, callback) 
     timestamp = record.time;
   }
 
-  // Date object in payload causes failure
-  delete record.time;
+  strictJSON(record);
 
   var entry = this.log.entry(this.resource, record);
+
   // There are no public APIs for this yet:
   // https://github.com/GoogleCloudPlatform/gcloud-node/issues/1348
   entry.timestamp = timestamp;
@@ -95,6 +103,26 @@ BunyanStackDriver.prototype._write = function write(record, encoding, callback) 
 
   callback();
 };
+
+/**
+ * Convert JS standard objects to strings, remove undefined
+ * https://github.com/GoogleCloudPlatform/gcloud-node/issues/1353
+ * https://github.com/GoogleCloudPlatform/gcloud-node/issues/1352
+ * Not cycle-safe.
+ * https://github.com/GoogleCloudPlatform/gcloud-node/issues/1354
+ */
+function strictJSON(o) {
+  for (var k in o) {
+    var v = o[k];
+    if (v instanceof Date || v instanceof Error || v instanceof RegExp) {
+      o[k] = v.toJSON();
+    } else if (v === undefined) {
+      delete o[k];
+    } else if (typeof v === "object") {
+      strictJSON(v);
+    }
+  }
+}
 
 BunyanStackDriver.prototype._writeToServer = function () {
   var self = this;

--- a/lib/bunyan-stackdriver.js
+++ b/lib/bunyan-stackdriver.js
@@ -1,5 +1,5 @@
 var util = require('util');
-var google = require('gcloud');
+var logging = require('@google-cloud/logging');
 var Writable = require('stream').Writable;
 
 const nameFromLevel = {
@@ -40,7 +40,7 @@ function BunyanStackDriver(options, error) {
   this.error = error || function() {};
 
   // ms. GCP's default limit is 20 RPS.
-  this.writeInterval = "writeInterval" in options ? options.writeInterval : 500;
+  this.writeInterval = 'writeInterval' in options ? options.writeInterval : 500;
 
   // object(MonitoredResource)
   // https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/MonitoredResource
@@ -57,13 +57,13 @@ function BunyanStackDriver(options, error) {
       labels: {}
     };
   }
-  
+
   // If not provided, gcloud will attempt automatic auth.
   if (options.keyFilename) {
     gopts.keyFilename = options.authJSON;
   }
 
-  var loggingClient = google(gopts).logging();
+  var loggingClient = logging(gopts);
 
   this.log = loggingClient.log(logName);
 
@@ -77,7 +77,7 @@ BunyanStackDriver.prototype._write = function write(record, encoding, callback) 
   if (typeof record === 'string') {
     if (once) {
       once = false;
-      console.warn("BunyanStackDriver: use 'streams: [ type: \"raw\", stream: new BunyanStackDriver(...) ]' for better performance.");
+      console.warn('BunyanStackDriver: use "streams: [ type: \"raw\", stream: new BunyanStackDriver(...) ]" for better performance.');
     }
     record = JSON.parse(record);
     timestamp = new Date(record.time);
@@ -105,10 +105,8 @@ BunyanStackDriver.prototype._write = function write(record, encoding, callback) 
 };
 
 /**
- * Convert JS standard objects to strings, remove undefined
- * https://github.com/GoogleCloudPlatform/gcloud-node/issues/1353
- * https://github.com/GoogleCloudPlatform/gcloud-node/issues/1352
- * Not cycle-safe.
+ * Convert JS standard objects to strings, remove undefined. This is not
+ * cycle-safe.
  * https://github.com/GoogleCloudPlatform/gcloud-node/issues/1354
  */
 function strictJSON(o) {
@@ -118,7 +116,7 @@ function strictJSON(o) {
       o[k] = v.toJSON();
     } else if (v === undefined) {
       delete o[k];
-    } else if (typeof v === "object") {
+    } else if (typeof v === 'object') {
       strictJSON(v);
     }
   }
@@ -132,9 +130,8 @@ BunyanStackDriver.prototype._writeToServer = function () {
   // Atomically get the entries to send and clear the queue
   var entries = this.entryQueue.splice(0);
 
-  // https://github.com/GoogleCloudPlatform/gcloud-node/issues/1349
   var options = {
-  //  partialSuccess: true
+    partialSuccess: true
   };
 
   this.log.write(entries, options, function (err, response) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunyan-stackdriver",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "StackDriver stream for Bunyan",
   "main": "./lib/bunyan-stackdriver",
   "repository": {
@@ -21,13 +21,14 @@
   },
   "homepage": "https://github.com/mlazarov/bunyan-stackdriver",
   "dependencies": {
-    "gcloud": "^0.34.0"
+    "@google-cloud/logging": "^0.1.1"
   },
   "devDependencies": {
     "bunyan": "^1.3.3"
   },
   "maintainers": [
-    "mlazarov <martin@lazarov.bg>"
+    "mlazarov <martin@lazarov.bg>",
+    "zbjornson <zbbjornson@gmail.com>"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/mlazarov/bunyan-stackdriver",
   "dependencies": {
-    "googleapis": "^4.0.0"
+    "gcloud": "^0.34.0"
   },
   "devDependencies": {
     "bunyan": "^1.3.3"


### PR DESCRIPTION
I got a bit carried away after making a small change and ended up making a lot of changes. You have a nice start here and I'm usually in favor of helping develop a single nice library instead of making multiple libraries with the same intended purpose, but I can make this a separate lib if you prefer.
- Rename options to match the GCP API option names: project -> projectId, authJSON -> keyFilename, log_id -> logName.
- Allow authorization to happen automatically when running on GCP (omit `keyFilename` for this).
- Allow projectId to be passed as an environment variable, following the gcloud lib model.
- Critical: batch messages together so that the API rate limit (20 RPS) won't be hit.
- Map bunyan's "fatal" to "alert" instead of "emergency".
- Fully validate `resource` if passed as an option.
- Allow use of object-mode streams from Bunyan for performance. (Normal buffer streams still work, but will print a warning once.)
- Set the timestamp from Bunyan on the actual GCP log entry. (Otherwise it gets set to the time that it was received.)
- Remove JSON.parse outside of try/catch block.
- Use gcloud lib instead of googleapis. Simpler usage...

I removed the "customFormatter" as I wasn't sure what the use case was. At least one of the if/elseif/else blocks was unreachable.

There are a few outstanding items:
- Cannot use partialSuccess with the gcloud lib (https://github.com/GoogleCloudPlatform/gcloud-node/issues/1349).
- Circular message objects will cause a stack overflow (https://github.com/GoogleCloudPlatform/gcloud-node/issues/1354)
