### PR TITLE
Set record.message to ensure msg is shown in the Stackdriver UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ limit is 20 RPS. The default setting for BunyanStackDriver is 500 ms.)
 
 * errorCallback. Will report errors during the logging process itself.
 
+## Stackdriver Error Reporting
+
+When errors with stack traces are logged - `bunyan.error(new Error('message'))` - these can automatically be captured by the [Error Reporting](https://cloud.google.com/error-reporting/) interface in Google Cloud Platform. To do so some additional configuration is required as per [Stackdriver Formatting Error Messages](https://cloud.google.com/error-reporting/docs/formatting-error-messages)
+
+When logging, a _service context_ is required. This can be added on a per log basis or configured for all logs during logger creation like so:
+
+```
+const logger = bunyan.createLogger({
+    name: 'Example',
+    serializers: ...
+    streams: ...,
+    serviceContext: {
+        service: 'example',
+        version: 'x.x.x'
+    }
+});
+```
+
 ## Links
 
 [Stackdriver Logging - Method entries.write](https://cloud.google.com/logging/docs/api/ref_v2beta1/rest/v2beta1/entries/write)

--- a/lib/bunyan-stackdriver.js
+++ b/lib/bunyan-stackdriver.js
@@ -93,7 +93,9 @@ BunyanStackDriver.prototype._write = function write(record, encoding, callback) 
   record = destroyCircular(record);
   strictJSON(record);
 
-  if (!record.message) {
+  if (record.err) {
+      record.message = record.err.stack;
+  } else if (!record.message) {
     record.message = record.msg;
   }
 

--- a/lib/bunyan-stackdriver.js
+++ b/lib/bunyan-stackdriver.js
@@ -93,6 +93,10 @@ BunyanStackDriver.prototype._write = function write(record, encoding, callback) 
   record = destroyCircular(record);
   strictJSON(record);
 
+  if (!record.message) {
+    record.message = record.msg;
+  }
+
   var metadata = {
     resource: this.resource,
     timestamp: timestamp,

--- a/lib/bunyan-stackdriver.js
+++ b/lib/bunyan-stackdriver.js
@@ -93,7 +93,7 @@ BunyanStackDriver.prototype._write = function write(record, encoding, callback) 
   record = destroyCircular(record);
   strictJSON(record);
 
-  if (record.err) {
+  if (record.err && record.err.stack) {
       record.message = record.err.stack;
   } else if (!record.message) {
     record.message = record.msg;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/mlazarov/bunyan-stackdriver",
   "dependencies": {
-    "@google-cloud/logging": "^0.5.0",
+    "@google-cloud/logging": "^0.7.0",
     "destroy-circular": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunyan-stackdriver",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "StackDriver stream for Bunyan",
   "main": "./lib/bunyan-stackdriver",
   "repository": {


### PR DESCRIPTION
This is quite a small change and there may be a better or more idiomatic way to achieve this but I found that this change was need to change this:

![screen shot 2017-02-03 at 11 43 10](https://cloud.githubusercontent.com/assets/160936/22590237/15a25060-ea06-11e6-8bec-65fc741a9206.png)

to this:

![screen shot 2017-02-03 at 11 43 32](https://cloud.githubusercontent.com/assets/160936/22590242/1ddbebec-ea06-11e6-9ada-f2c70ed9a1b1.png)

