### PR TITLE
Update dependency, add note about official package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # bunyan-stackdriver
 
-**Bunyan stream for StackDriver (Google Cloud Logging API) integration**
+Bunyan stream for StackDriver (Google Cloud Logging API) integration.
+
+**:exclamation: Google Cloud now has an official Bunyan logging transport that should be preferred over this library: https://github.com/GoogleCloudPlatform/google-cloud-node/tree/master/packages/logging-bunyan**
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/mlazarov/bunyan-stackdriver",
   "dependencies": {
-    "@google-cloud/logging": "^0.7.0",
+    "@google-cloud/logging": "^1.0.4",
     "destroy-circular": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
* Update dependency to avoid vulnerable version of tunnel-agent.

* Add note about official library. I haven't tried it out yet and I'm not sure if there are any remaining differences. I gave them some early feedback that they addressed; I think it's a valid replacement.